### PR TITLE
One last edge case for private team scanning

### DIFF
--- a/main.go
+++ b/main.go
@@ -593,7 +593,7 @@ func checkflags(token string, org string, user string, repoURL string, gistURL s
 					os.Exit(2)
 				}
 			}
-		} else if org != "" {
+		} else if org != "" && teamName == "" {
 			var orgRepos []*github.Repository
 
 			opt3 := &github.RepositoryListByOrgOptions{


### PR DESCRIPTION
There's still an edge case with team scanning. If one does not provide `-scanPrivateReposOnly=true`, https auth is still requested for repo cloning:

    # ./gitallsecrets -token=xxx -org=xxx -orgOnly=1 -teamName=xxxxxx -toolName=thog -user=""
    Org was specified combined with orgOnly, the tool will proceed to scan only the org repos and nothing related to its users
    Cloning the repositories of the organization: SimpliSafe
    If the token provided belongs to a user in this organization, this will also clone all public AND private repositories of this org, irrespecitve of the scanPrivateReposOnly flag being set..
    https://github.com/...
    xxxxx fork and the cloneFork flag was set to false so moving on..
    Done cloning org repos.
    Since team name was provided, the tool will clone all repos to which the team has access
    Listing teams...
    Cloning the repositories of the team: XXXXXXXXX(NNNNNNNN)
    Listing team repositories...
    https://github.com/xxx/...
    https://github.com/xxx/...
    https://github.com/xxx/...
    ...

    Username for 'https://github.com': Username for 'https://github.com': Username for 'https://github.com': Username for 'https://github.com': Username for 'https://github.com': Username for 'https://github.com': Username for 'https://github.com': Username for 'https://github.com': Username for 'https://github.com': Username for 'https://github.com': ^C

If one *does* provide `-scanPrivateReposOnly=true`, then the team based scanning is not done:

    # ./gitallsecrets -token=xxx -org=xxx -orgOnly=1 -teamName=xxxxxx -toolName=thog -scanPrivateReposOnly=true
    scanPrivateReposOnly flag is provided with either the user, the repoURL or the org
    Checking to see if the SSH key exists or not..
    SSH key exists and file size > 0 so continuing..
    scanPrivateReposOnly flag is provided along with the org
    Checking to see if the token provided belongs to a user in the org or not..
    Even though the token belongs to a user in this org, there are no Private repos in this org

With the attached fix, private team scanning does run:

    # ./gitallsecrets -token=xxx -org=xxx -orgOnly=1 -teamName=xxxxxx -toolName=thog -scanPrivateReposOnly=true
    scanPrivateReposOnly flag is provided with either the user, the repoURL or the org
    Checking to see if the SSH key exists or not..
    SSH key exists and file size > 0 so continuing..
    Org was specified combined with orgOnly, the tool will proceed to scan only the org repos and nothing related to its users
    Cloning the repositories of the organization: SimpliSafe
    If the token provided belongs to a user in this organization, this will also clone all public AND private repositories of this org, irrespecitve of the scanPrivateReposOnly flag being set..
    xxx is a fork and the cloneFork flag was set to false so moving on..
    git@github.com:xxx/...
    Done cloning org repos.
    Since team name was provided, the tool will clone all repos to which the team has access
    Listing teams...
    Cloning the repositories of the team: xxxxxx(NNNNNNN)
    Listing team repositories...
    git@github.com:xxx/...
    git@github.com:xxx/...
    xxx is a fork and the cloneFork flag was set to false so moving on..
    ...

Matt