### PR TITLE
Fixing issue #25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,8 @@ FROM node:9.11.2-alpine
 
 COPY --from=build-env /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=build-env /go/bin/git-all-secrets /usr/bin/git-all-secrets
-
 RUN apk add --no-cache --upgrade git python py-pip jq
+ENV PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 # Create a generic SSH config for Github
 WORKDIR /root/.ssh
@@ -31,7 +31,7 @@ RUN echo "Host *github.com \
 \n  StrictHostKeyChecking no \
 \n  UserKnownHostsFile=/dev/null \
 \n  IdentityFile /root/.ssh/id_rsa" > config
-
+RUN ssh-keyscan -H github.com >> /root/.ssh/known_hosts
 RUN git clone https://github.com/anshumanbh/repo-supervisor.git /root/repo-supervisor
 
 # Install truffleHog
@@ -47,5 +47,6 @@ RUN npm install --no-optional && \
     npm run build && \
     npm run cli ./src/
 
+ENV PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 WORKDIR /root/
 ENTRYPOINT [ "git-all-secrets" ]


### PR DESCRIPTION
As defined in issue #25, I was able to replicate an issue where git couldn't locate the path to the ssh client when cloning an org's private repos. In addition to this, I also had an issue with the ssh'ing without the known hosts. 

I've set the path in both containers, and added a known hosts file.